### PR TITLE
Provide access to the main response node

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,13 @@ If HTTP response is not `200`, then `Gajus\Strading\Exception\RuntimeException` 
 public function getTransaction ();
 
 /**
+ * Return the main response node
+ *
+ * @return SimpleXMLElement
+ */
+public function getResponseNode();
+
+/**
  * This information is available when response type is "ERROR".
  *
  * @return null|Gajus\Strading\Error

--- a/src/Response.php
+++ b/src/Response.php
@@ -27,7 +27,11 @@ class Response
         /**
          * @var string
          */
-        $redirect_url;
+        $redirect_url,
+        /**
+         * @var \SimpleXMLElement
+         */
+        $response_node;
 
     /**
      * @param SimpleXMLElement $xml Response body.
@@ -39,7 +43,7 @@ class Response
 
         // PHP 5.3 does not allow array access to the method response.
         $response = $this->xml->xpath('/responseblock/response');
-        $response = $response[0];
+        $this->response_node = $response = $response[0];
 
         $this->type = $response->attributes();
         $this->type = (string)$this->type['type'];
@@ -91,6 +95,16 @@ class Response
     public function getTransaction()
     {
         return $this->transaction;
+    }
+
+    /**
+     * Return the main response node
+     *
+     * @return SimpleXMLElement
+     */
+    public function getResponseNode()
+    {
+        return $this->response_node;
     }
 
     /**


### PR DESCRIPTION
getTransaction() populates a number of data in the transaction array but
they're usually not enough. Added getResponseNode() so you have access
to the full response data